### PR TITLE
Fehler bei den Tests Beheben

### DIFF
--- a/src/visuanalytics/Dockerfile
+++ b/src/visuanalytics/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-slim-buster
 
 # install GCC
-RUN apt-get update && apt-get install -y gcc
+RUN apt-get update && apt-get install -y gcc g++
 
 # install Requirements
 COPY requirements.txt /tmp/


### PR DESCRIPTION
Damit alle Dependencies richtig installiert werden fehlt im Docker Container das Programm `g++`. (Fehlermeldung: ` gcc: error trying to exec 'cc1plus': execvp: No such file or directory`)